### PR TITLE
Update Extbase-validation for TYPO3 v10

### DIFF
--- a/Classes/Controller/SurveyController.php
+++ b/Classes/Controller/SurveyController.php
@@ -92,6 +92,8 @@ class SurveyController extends AbstractController
      * @param Question $currentQuestion
      * @validate $survey \Pixelant\PxaSurvey\Domain\Validation\Validator\SurveyAnswerValidator
      * @validate $survey \Pixelant\PxaSurvey\Domain\Validation\Validator\ReCaptchaValidator
+     * @Extbase\Validate("\Pixelant\PxaSurvey\Domain\Validation\Validator\SurveyAnswerValidator", param="survey")
+     * @Extbase\Validate("\Pixelant\PxaSurvey\Domain\Validation\Validator\ReCaptchaValidator", param="survey")
      */
     public function answerAction(Survey $survey, Question $currentQuestion = null)
     {


### PR DESCRIPTION
Migrated validators according to:
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.3/Deprecation-83167-ReplaceValidateWithTYPO3CMSExtbaseAnnotationValidate.html

# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [X] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
Classic @validate was deprecated with TYPO3 v9.3 and removed in v10. Update syntax but still keep the old syntax for compat with older TYPO3-versions, if we want to.